### PR TITLE
Add "required" annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ type Config struct {
 
     AWS struct {
         ID     string `env:"AWS_ACCESS_KEY_ID"`
-        Secret string `env:"AWS_SECRET_ACCESS_KEY"`
+        Secret string `env:"AWS_SECRET_ACCESS_KEY,required"`
     }
 }
 ```


### PR DESCRIPTION
Fix #2

This change adds the "required" annotation. The "required" annotation requires the environment variable to be present. If it is not present, an error message is printed and the program exits.

The exit behavior is in the FailureFunc variable. This variable can be changed to allow for custom behavior upon required environment variable failure.

This change is backward compatible with previous releases. No user-programmer code will need to be updated.
