### PR TITLE
Add support to decode slices from the environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ type Config struct {
     Port      uint16 `env:"SERVER_PORT,default=8080"`
 
     AWS struct {
-        ID     string `env:"AWS_ACCESS_KEY_ID"`
-        Secret string `env:"AWS_SECRET_ACCESS_KEY,required"`
+        ID        string   `env:"AWS_ACCESS_KEY_ID"`
+        Secret    string   `env:"AWS_SECRET_ACCESS_KEY,required"`
+        SnsTopics []string `env:"AWS_SNS_TOPICS"`
     }
 
     Timeout time.Duration `env:"TIMEOUT,default=1m"`
@@ -44,6 +45,7 @@ err := envdecode.Decode(&cfg)
 ## Supported types ##
 
 * Structs (and pointer to structs)
+* Slices of below defined types
 * `bool`
 * `float32`, `float64`
 * `int`, `int8`, `int16`, `int32`, `int64`

--- a/envdecode.go
+++ b/envdecode.go
@@ -46,7 +46,8 @@ var FailureFunc = func(err error) {
 // those types.  Structs and pointers to structs are decoded
 // recursively.  time.Duration is supported via the
 // time.ParseDuration() function and *url.URL is supported via the
-// url.Parse() function.
+// url.Parse() function. Slices are supported for all above mentioned
+// primitive types. Comma is used as delimiter in environment variables.
 func Decode(target interface{}) error {
 	nFields, err := decode(target)
 	if err != nil {
@@ -131,61 +132,90 @@ func decode(target interface{}) (int, error) {
 		if env == "" {
 			env = defaultValue
 		}
-
 		if env == "" {
 			continue
 		}
 
 		setFieldCount++
 
-		switch f.Kind() {
-		case reflect.Bool:
-			v, err := strconv.ParseBool(env)
-			if err == nil {
-				f.SetBool(v)
-			}
-
-		case reflect.Float32, reflect.Float64:
-			bits := f.Type().Bits()
-			v, err := strconv.ParseFloat(env, bits)
-			if err == nil {
-				f.SetFloat(v)
-			}
-
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			if t := f.Type(); t.PkgPath() == "time" && t.Name() == "Duration" {
-				v, err := time.ParseDuration(env)
-				if err == nil {
-					f.SetInt(int64(v))
-				}
-			} else {
-				bits := f.Type().Bits()
-				v, err := strconv.ParseInt(env, 0, bits)
-				if err == nil {
-					f.SetInt(v)
-				}
-			}
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			bits := f.Type().Bits()
-			v, err := strconv.ParseUint(env, 0, bits)
-			if err == nil {
-				f.SetUint(v)
-			}
-
-		case reflect.String:
-			f.SetString(env)
-
-		case reflect.Ptr:
-			if t := f.Type().Elem(); t.Kind() == reflect.Struct && t.PkgPath() == "net/url" && t.Name() == "URL" {
-				v, err := url.Parse(env)
-				if err == nil {
-					f.Set(reflect.ValueOf(v))
-				}
-			}
+		if f.Kind() == reflect.Slice {
+			decodeSlice(&f, env)
+		} else {
+			decodePrimitiveType(&f, env)
 		}
 	}
 
 	return setFieldCount, nil
+}
+
+func decodeSlice(f *reflect.Value, env string) {
+	parts := strings.Split(env, ",")
+
+	values := parts[:0]
+	for _, x := range parts {
+		if x != "" {
+			values = append(values, strings.TrimSpace(x))
+		}
+	}
+
+	valuesCount := len(values)
+	slice := reflect.MakeSlice(f.Type(), valuesCount, valuesCount)
+	if valuesCount > 0 {
+		for i := 0; i < valuesCount; i++ {
+			e := slice.Index(i)
+			decodePrimitiveType(&e, values[i])
+		}
+	}
+
+	f.Set(slice)
+}
+
+func decodePrimitiveType(f *reflect.Value, env string) {
+	switch f.Kind() {
+	case reflect.Bool:
+		v, err := strconv.ParseBool(env)
+		if err == nil {
+			f.SetBool(v)
+		}
+
+	case reflect.Float32, reflect.Float64:
+		bits := f.Type().Bits()
+		v, err := strconv.ParseFloat(env, bits)
+		if err == nil {
+			f.SetFloat(v)
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if t := f.Type(); t.PkgPath() == "time" && t.Name() == "Duration" {
+			v, err := time.ParseDuration(env)
+			if err == nil {
+				f.SetInt(int64(v))
+			}
+		} else {
+			bits := f.Type().Bits()
+			v, err := strconv.ParseInt(env, 0, bits)
+			if err == nil {
+				f.SetInt(v)
+			}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		bits := f.Type().Bits()
+		v, err := strconv.ParseUint(env, 0, bits)
+		if err == nil {
+			f.SetUint(v)
+		}
+
+	case reflect.String:
+		f.SetString(env)
+
+	case reflect.Ptr:
+		if t := f.Type().Elem(); t.Kind() == reflect.Struct && t.PkgPath() == "net/url" && t.Name() == "URL" {
+			v, err := url.Parse(env)
+			if err == nil {
+				f.Set(reflect.ValueOf(v))
+			}
+		}
+	}
 }
 
 // MustDecode calls Decode and terminates the process if any errors
@@ -299,6 +329,9 @@ func Export(target interface{}) ([]*ConfigInfo, error) {
 
 			case reflect.String:
 				ci.Value = f.String()
+
+			case reflect.Slice:
+				ci.Value = fmt.Sprintf("%v", f.Interface())
 
 			default:
 				// Unable to determine string format for value


### PR DESCRIPTION
This change allow to use slices of all supported primitive types in configuration structs. Delimiter for splitting environment variable is comma. This change is backward compatible with previous releases. 