### PR TITLE
Fix docs for config members that are slices of things

### DIFF
--- a/envdecode.go
+++ b/envdecode.go
@@ -47,7 +47,7 @@ var FailureFunc = func(err error) {
 // recursively.  time.Duration is supported via the
 // time.ParseDuration() function and *url.URL is supported via the
 // url.Parse() function. Slices are supported for all above mentioned
-// primitive types. Comma is used as delimiter in environment variables.
+// primitive types. Semicolon is used as delimiter in environment variables.
 func Decode(target interface{}) error {
 	nFields, err := decode(target)
 	if err != nil {


### PR DESCRIPTION
Slices of things are currently documented to be parsed as comma-delimited, but [the tests clearly show they are actually semicolon-delimited](https://github.com/joeshaw/envdecode/blob/master/envdecode_test.go#L91). This brings the docs in line with the current behavior.