### PR TITLE
More clear error types in decoding

### DIFF
--- a/envdecode.go
+++ b/envdecode.go
@@ -18,6 +18,7 @@ import (
 // ErrInvalidTarget indicates that the target value passed to
 // Decode is invalid.  Target must be a non-nil pointer to a struct.
 var ErrInvalidTarget = errors.New("target must be non-nil pointer to struct that has at least one exported field with a valid env tag.")
+var ErrNoTargetFieldsAreSet = errors.New("none of the target fields were set from environment variables")
 
 // FailureFunc is called when an error is encountered during a MustDecode
 // operation. It prints the error and terminates the process.
@@ -63,7 +64,7 @@ func Decode(target interface{}) error {
 	// if we didn't do anything - the user probably did something
 	// wrong like leave all fields unexported.
 	if nFields == 0 {
-		return ErrInvalidTarget
+		return ErrNoTargetFieldsAreSet
 	}
 
 	return nil

--- a/envdecode_test.go
+++ b/envdecode_test.go
@@ -61,6 +61,10 @@ type testConfig struct {
 	DefaultURL      *url.URL      `env:"TEST_UNSET,default=http://example.com"`
 }
 
+type testConfigNoSet struct {
+	Some string `env:"TEST_THIS_ENV_WILL_NOT_BE_SET"`
+}
+
 type testConfigRequired struct {
 	Required string `env:"TEST_REQUIRED,required"`
 }
@@ -316,13 +320,13 @@ func TestDecodeErrors(t *testing.T) {
 
 	var tnt testNoTags
 	err = Decode(&tnt)
-	if err != ErrInvalidTarget {
+	if err != ErrNoTargetFieldsAreSet {
 		t.Fatal("Should have gotten an error decoding a struct with no tags")
 	}
 
 	var tcni testNoExportedFields
 	err = Decode(&tcni)
-	if err != ErrInvalidTarget {
+	if err != ErrNoTargetFieldsAreSet {
 		t.Fatal("Should have gotten an error decoding a struct with no unexported fields")
 	}
 
@@ -331,6 +335,12 @@ func TestDecodeErrors(t *testing.T) {
 	err = Decode(&tcr)
 	if err == nil {
 		t.Fatal("An error was expected but recieved:", err)
+	}
+
+	var tcns testConfigNoSet
+	err = Decode(&tcns)
+	if err != ErrNoTargetFieldsAreSet {
+		t.Fatal("Should have gotten an error decoding when no env variables are set")
 	}
 
 	missing := false
@@ -378,7 +388,7 @@ func TestOnlyNested(t *testing.T) {
 	var o3 struct {
 		Inner noConfig
 	}
-	if err := Decode(&o3); err != ErrInvalidTarget {
+	if err := Decode(&o3); err != ErrNoTargetFieldsAreSet {
 		t.Fatal("Expected ErrInvalidTarget, got %s", err)
 	}
 }


### PR DESCRIPTION
Using the `ErrInvalidTarget` as the only available error could be misleading in some edge cases. Consider the case:

```
type Config struct {
    Foo string `env:"TEST_FOO"`
}

var cfg Config
```

Variable `&cfg` is perfectly valid for the purpose of decoding, but decoding into this variable when env `TEST_FOO` is not set will currently produce error `ErrInvalidTarget`. In fact, I've encountered a situation when I don't even want to consider this an error at all.

This pull request introduces a separate error for cases of this kind, which makes it easier to ignore this error or to handle it differently. 
