### PR TITLE
add strict meta descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ type Config struct {
         SnsTopics []string `env:"AWS_SNS_TOPICS"`
     }
 
-    Timeout time.Duration `env:"TIMEOUT,default=1m"`
+    Timeout time.Duration `env:"TIMEOUT,default=1m,strict"`
 }
 ```
 
@@ -41,6 +41,15 @@ Then call `envdecode.Decode`:
 var cfg Config
 err := envdecode.Decode(&cfg)
 ```
+
+If you want all fields to act `strict`, you may use `envdecode.StrictDecode`:
+
+```go
+var cfg Config
+err := envdecode.StrictDecode(&cfg)
+```
+
+All parse errors will fail fast and return an error in this mode.
 
 ## Supported types ##
 

--- a/envdecode.go
+++ b/envdecode.go
@@ -44,7 +44,9 @@ type Decoder interface {
 // Default values may be provided by appending ",default=value" to the
 // struct tag.  Required values may be marked by appending ",required"
 // to the struct tag.  It is an error to provide both "default" and
-// "required".
+// "required". Strict values may be marked by appending ",strict" which
+// will return an error on Decode if there is an error while parsing.
+// If everything must be strict, consider using StrictDecode instead.
 //
 // All primitive types are supported, including bool, floating point,
 // signed and unsigned integers, and string.  Boolean and numeric
@@ -55,7 +57,7 @@ type Decoder interface {
 // url.Parse() function. Slices are supported for all above mentioned
 // primitive types. Semicolon is used as delimiter in environment variables.
 func Decode(target interface{}) error {
-	nFields, err := decode(target)
+	nFields, err := decode(target, false)
 	if err != nil {
 		return err
 	}
@@ -69,7 +71,24 @@ func Decode(target interface{}) error {
 	return nil
 }
 
-func decode(target interface{}) (int, error) {
+// StrictDecode is similar to Decode except all fields will have an implicit
+// ",strict" on all fields.
+func StrictDecode(target interface{}) error {
+	nFields, err := decode(target, true)
+	if err != nil {
+		return err
+	}
+
+	// if we didn't do anything - the user probably did something
+	// wrong like leave all fields unexported.
+	if nFields == 0 {
+		return ErrInvalidTarget
+	}
+
+	return nil
+}
+
+func decode(target interface{}, strict bool) (int, error) {
 	s := reflect.ValueOf(target)
 	if s.Kind() != reflect.Ptr || s.IsNil() {
 		return 0, ErrInvalidTarget
@@ -83,6 +102,9 @@ func decode(target interface{}) (int, error) {
 	t := s.Type()
 	setFieldCount := 0
 	for i := 0; i < s.NumField(); i++ {
+		// Localize the umbrella `strict` value to the specific field.
+		strict := strict
+
 		f := s.Field(i)
 
 		switch f.Kind() {
@@ -101,7 +123,7 @@ func decode(target interface{}) (int, error) {
 				break
 			}
 
-			n, err := decode(ss)
+			n, err := decode(ss, strict)
 			if err != nil {
 				return 0, err
 			}
@@ -132,6 +154,9 @@ func decode(target interface{}) (int, error) {
 				hasDefault = true
 				defaultValue = o[8:]
 			}
+			if !strict {
+				strict = strings.HasPrefix(o, "strict")
+			}
 		}
 
 		if required && hasDefault {
@@ -151,11 +176,15 @@ func decode(target interface{}) (int, error) {
 
 		decoder, custom := f.Addr().Interface().(Decoder)
 		if custom {
-			decoder.Decode(env)
+			if err := decoder.Decode(env); err != nil {
+				return 0, err
+			}
 		} else if f.Kind() == reflect.Slice {
 			decodeSlice(&f, env)
 		} else {
-			decodePrimitiveType(&f, env)
+			if err := decodePrimitiveType(&f, env); err != nil && strict {
+				return 0, err
+			}
 		}
 	}
 
@@ -184,40 +213,45 @@ func decodeSlice(f *reflect.Value, env string) {
 	f.Set(slice)
 }
 
-func decodePrimitiveType(f *reflect.Value, env string) {
+func decodePrimitiveType(f *reflect.Value, env string) error {
 	switch f.Kind() {
 	case reflect.Bool:
 		v, err := strconv.ParseBool(env)
-		if err == nil {
-			f.SetBool(v)
+		if err != nil {
+			return err
 		}
+		f.SetBool(v)
 
 	case reflect.Float32, reflect.Float64:
 		bits := f.Type().Bits()
 		v, err := strconv.ParseFloat(env, bits)
-		if err == nil {
-			f.SetFloat(v)
+		if err != nil {
+			return err
 		}
+		f.SetFloat(v)
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		if t := f.Type(); t.PkgPath() == "time" && t.Name() == "Duration" {
 			v, err := time.ParseDuration(env)
-			if err == nil {
-				f.SetInt(int64(v))
+			if err != nil {
+				return err
 			}
+			f.SetInt(int64(v))
 		} else {
 			bits := f.Type().Bits()
 			v, err := strconv.ParseInt(env, 0, bits)
-			if err == nil {
-				f.SetInt(v)
+			if err != nil {
+				return err
 			}
+			f.SetInt(v)
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		bits := f.Type().Bits()
 		v, err := strconv.ParseUint(env, 0, bits)
-		if err == nil {
-			f.SetUint(v)
+		if err != nil {
+			return err
 		}
+		f.SetUint(v)
 
 	case reflect.String:
 		f.SetString(env)
@@ -225,17 +259,28 @@ func decodePrimitiveType(f *reflect.Value, env string) {
 	case reflect.Ptr:
 		if t := f.Type().Elem(); t.Kind() == reflect.Struct && t.PkgPath() == "net/url" && t.Name() == "URL" {
 			v, err := url.Parse(env)
-			if err == nil {
-				f.Set(reflect.ValueOf(v))
+			if err != nil {
+				return err
 			}
+			f.Set(reflect.ValueOf(v))
 		}
 	}
+	return nil
 }
 
 // MustDecode calls Decode and terminates the process if any errors
 // are encountered.
 func MustDecode(target interface{}) {
 	err := Decode(target)
+	if err != nil {
+		FailureFunc(err)
+	}
+}
+
+// MustStrictDecode calls StrictDecode and terminates the process if any errors
+// are encountered.
+func MustStrictDecode(target interface{}) {
+	err := StrictDecode(target)
 	if err != nil {
 		FailureFunc(err)
 	}


### PR DESCRIPTION
This change adds the ability to flag an env var as `strict`.
Strict env vars will throw an error if parsing fails.

In all honesty, this is a good default to have, but given that
it's a breaking change, opting to make it optional is probably
the more prudent change.