### PR TITLE
check CanInterface before calling Interface

### DIFF
--- a/envdecode.go
+++ b/envdecode.go
@@ -118,6 +118,10 @@ func decode(target interface{}, strict bool) (int, error) {
 			fallthrough
 
 		case reflect.Struct:
+			if !f.Addr().CanInterface() {
+				continue
+			}
+
 			ss := f.Addr().Interface()
 			_, custom := ss.(Decoder)
 			if custom {

--- a/envdecode_test.go
+++ b/envdecode_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -59,6 +60,8 @@ type testConfig struct {
 	DefaultSliceInt []int         `env:"TEST_UNSET,asdf=asdf,default=1;2;3"`
 	DefaultDuration time.Duration `env:"TEST_UNSET,asdf=asdf,default=24h"`
 	DefaultURL      *url.URL      `env:"TEST_UNSET,default=http://example.com"`
+
+	cantInterfaceField sync.Mutex
 }
 
 type testConfigNoSet struct {


### PR DESCRIPTION
Allows using fields for which Interface would panic.

cc @apg