### PR TITLE
Add options of decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.vscode/*
 example/example

--- a/envdecode_test.go
+++ b/envdecode_test.go
@@ -72,6 +72,14 @@ type testConfigRequired struct {
 	Required string `env:"TEST_REQUIRED,required"`
 }
 
+type testConfigForcedRequire struct {
+	NotRequired string `env:"TEST_NOTREQUIRED"`
+}
+
+type testConfigDisabledDefault struct {
+	Default string `env:"TEST_DISABLED_DEFAULT,default=test"`
+}
+
 type testConfigRequiredDefault struct {
 	RequiredDefault string `env:"TEST_REQUIRED_DEFAULT,required,default=test"`
 }
@@ -500,7 +508,7 @@ type testConfigStrict struct {
 
 func TestInvalidStrict(t *testing.T) {
 	cases := []struct {
-		decoder             func(interface{}) error
+		decoder             func(interface{}, ...Option) error
 		rootValue           string
 		nestedValue         string
 		rootValueImplicit   string
@@ -735,5 +743,32 @@ func TestExport(t *testing.T) {
 		if *ci != *v {
 			t.Fatalf("have %+v, expected %+v", v, ci)
 		}
+	}
+}
+
+func TestForcedRequirements(t *testing.T) {
+	os.Setenv("TEST_NOTREQUIRED", "notrequired")
+	var tc testConfigForcedRequire
+	if err := Decode(&tc); err != nil {
+		t.Fatal(err)
+	}
+	if tc.NotRequired != "notrequired" {
+		t.Fatalf("Expected \"notrequired\", got %s", tc.NotRequired)
+	}
+
+	os.Clearenv()
+	if err := Decode(&tc, WithForcedRequirement()); err == ErrNoTargetFieldsAreSet {
+		t.Fatal("An error was expected but recieved:", err)
+	}
+}
+
+func TestDisabledRequirements(t *testing.T) {
+	os.Clearenv()
+	var tc testConfigDisabledDefault
+	if err := Decode(&tc, WithoutDefaults()); err != ErrNoTargetFieldsAreSet {
+		t.Fatal(err)
+	}
+	if tc.Default != "" {
+		t.Fatalf("Expected \"\", got %s", tc.Default)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,35 @@
+package envdecode
+
+type config struct {
+	strict     bool
+	require    bool
+	nodefaults bool
+}
+
+type Option func(cfg *config)
+
+func WithStrictDecoding() Option {
+	return func(cfg *config) {
+		cfg.strict = true
+	}
+}
+
+func WithForcedRequirement() Option {
+	return func(cfg *config) {
+		cfg.require = true
+	}
+}
+
+func WithoutDefaults() Option {
+	return func(cfg *config) {
+		cfg.nodefaults = true
+	}
+}
+
+func newConfig(options ...Option) config {
+	cfg := config{}
+	for _, option := range options {
+		option(&cfg)
+	}
+	return cfg
+}


### PR DESCRIPTION
WithStrictDecoding
WithForcedRequirement
WithoutDefaults

Right now I'm migrating some servers to Kubernetes and I need to be sure that all environment variables are represented in helm charts. In similar cases WithForcedRequirement and WithoutDefaults could be used to make sure that nothing is forgotten.